### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,7 @@ jobs:
           ./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]} --enable-llvm --enable-linux --with-sim=qemu --enable-qemu-system
           sudo mkdir /mnt/riscv
           sudo chown $USER:$USER /mnt/riscv
+          touch gcc/gcc/testsuite/gcc.dg/cpp/_Pragma3.c
           make -j $(nproc) all build-sim
 
       - name: tarball build

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -79,6 +79,7 @@ jobs:
           fi
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
+          touch gcc/gcc/testsuite/gcc.dg/cpp/_Pragma3.c
           make -j $(nproc) ${{ matrix.mode }}
 
       - name: tarball build

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os:       [ubuntu-22.04, ubuntu-24.04]
-        mode:     [newlib, linux, musl, uclibc]
+        mode:     [linux]
         target:   [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
         exclude:


### PR DESCRIPTION
Only build linux, the other variants were dropped in 79b5437 ("TT: Remove unused modules").